### PR TITLE
Update babel-plugin-flow-react-proptypes to >= 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.26",
     "babel-eslint": "^6.0.0-beta.6",
-    "babel-plugin-flow-react-proptypes": "^0.2.4",
+    "babel-plugin-flow-react-proptypes": "^2.2.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.3.13",


### PR DESCRIPTION
Update babel-plugin-flow-react-proptypes to >= 1.0.0 in order to use PropTypes from the prop-types package, as accessing them from the main React object is being deprecated in React 15.5